### PR TITLE
Fix #8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,10 @@ jobs:
           brew install bash
           echo "$(brew --prefix)/bin" >> $GITHUB_PATH
       - name: Check formatting
-        run: |
-          unformatted=$(gofmt -l .)
-          if [ -n "$unformatted" ]; then
-            echo "The following files are not formatted:"
-            echo "$unformatted"
-            exit 1
-          fi
+        run: make fmt-check
       - name: Vet
-        run: go vet ./...
+        run: make vet
       - name: Unit tests
-        run: go test -v $(go list ./... | grep -v '/tests/e2e$')
+        run: make test-unit
       - name: E2E tests
-        run: go test -v ./tests/e2e
+        run: make test-e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,19 +26,13 @@ jobs:
           brew install bash
           echo "$(brew --prefix)/bin" >> $GITHUB_PATH
       - name: Check formatting
-        run: |
-          unformatted=$(gofmt -l .)
-          if [ -n "$unformatted" ]; then
-            echo "The following files are not formatted:"
-            echo "$unformatted"
-            exit 1
-          fi
+        run: make fmt-check
       - name: Vet
-        run: go vet ./...
+        run: make vet
       - name: Unit tests
-        run: go test -v $(go list ./... | grep -v '/tests/e2e$')
+        run: make test-unit
       - name: E2E tests
-        run: go test -v ./tests/e2e
+        run: make test-e2e
 
   release:
     needs: verify

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+.PHONY: fmt-check vet test-unit test-e2e test verify build install clean
+
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo unknown)
+BUILT_AT ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS = -X github.com/cmtonkinson/governator/internal/buildinfo.Version=$(VERSION) \
+	-X github.com/cmtonkinson/governator/internal/buildinfo.Commit=$(COMMIT) \
+	-X github.com/cmtonkinson/governator/internal/buildinfo.BuiltAt=$(BUILT_AT)
+
+fmt-check:
+	@unformatted="$$(gofmt -l .)"; \
+	if [ -n "$$unformatted" ]; then \
+		echo "The following files are not formatted:"; \
+		echo "$$unformatted"; \
+		exit 1; \
+	fi
+
+vet:
+	go vet ./...
+
+test-unit:
+	go test -v $$(go list ./... | grep -v '/tests/e2e$$')
+
+test-e2e:
+	go test -v ./tests/e2e
+
+test: test-unit test-e2e
+
+verify: fmt-check vet test
+
+build:
+	go build -ldflags "$(LDFLAGS)" -o governator .
+
+install:
+	go install -ldflags "$(LDFLAGS)" .
+
+clean:
+	rm -f governator

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ sudo dpkg -i governator_<version>_amd64.deb
 ```bash
 git clone https://github.com/cmtonkinson/governator.git
 cd governator
-go build -o governator .
+make build
 sudo mv governator /usr/local/bin/
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-go build -o governator .


### PR DESCRIPTION
## Summary
- add a root Makefile with canonical build/test/verify targets
- inject build metadata ldflags for local make build/install
- switch CI and release verify workflows to call make targets
- remove legacy build.sh and update README source build instructions

## Validation
- make build
- ./governator --version
- make verify
- go test ./...