### PR TITLE
Fix #4: remove non-functional TUI row selector

### DIFF
--- a/internal/tui/status.go
+++ b/internal/tui/status.go
@@ -87,7 +87,7 @@ func New(repoRoot string) Model {
 
 	taskTable := table.New(
 		table.WithColumns(taskColumns),
-		table.WithFocused(true),
+		table.WithFocused(false),
 		table.WithHeight(20),
 	)
 
@@ -98,10 +98,6 @@ func New(repoRoot string) Model {
 		BorderBottom(true).
 		Bold(true).
 		Foreground(lipgloss.Color("12"))
-	s.Selected = s.Selected.
-		Foreground(lipgloss.Color("229")).
-		Background(lipgloss.Color("57")).
-		Bold(false)
 	taskTable.SetStyles(s)
 
 	// Planning steps table
@@ -314,7 +310,7 @@ func (m Model) View() string {
 	if m.showMerged {
 		mergedToggle = "hide"
 	}
-	help := helpStyle.Render(fmt.Sprintf("↑/↓: navigate • r: refresh • m: %s merged • q/esc: quit", mergedToggle))
+	help := helpStyle.Render(fmt.Sprintf("r: refresh • m: %s merged • q/esc: quit", mergedToggle))
 	b.WriteString(help)
 
 	// Error display

--- a/internal/tui/status_test.go
+++ b/internal/tui/status_test.go
@@ -1,0 +1,30 @@
+// Package tui tests interactive status model behavior.
+package tui
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNewTaskTableNotFocused ensures task rows are not interactively selectable.
+func TestNewTaskTableNotFocused(t *testing.T) {
+	model := New(".")
+	if model.table.Focused() {
+		t.Fatal("task table is focused; expected unfocused to disable row selector")
+	}
+}
+
+// TestViewHelpDoesNotAdvertiseNavigation ensures footer help matches supported controls.
+func TestViewHelpDoesNotAdvertiseNavigation(t *testing.T) {
+	model := New(".")
+	model.lastUpdate = time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+	view := model.View()
+	if strings.Contains(view, "navigate") || strings.Contains(view, "↑/↓") {
+		t.Fatalf("view contains row-navigation help text: %q", view)
+	}
+	if !strings.Contains(view, "r: refresh") {
+		t.Fatalf("view missing refresh help text: %q", view)
+	}
+}


### PR DESCRIPTION
## Summary
- remove focused/selectable task row behavior from the interactive status TUI
- update status footer help text to remove up/down navigation hint
- add unit tests to ensure the task table remains unfocused and help text reflects supported controls

Closes #4.

## Validation
- go test ./...