### PR TITLE
Fix #3: gov why shows historical failures incorrectly

### DIFF
--- a/main.go
+++ b/main.go
@@ -1099,9 +1099,6 @@ func whyTaskKind(task index.Task, supervisorState supervisor.SupervisorStateInfo
 	if task.State == index.TaskStateBlocked {
 		return "blocked"
 	}
-	if task.Attempts.Failed > 0 {
-		return "failed"
-	}
 	if task.Kind == index.TaskKindPlanning &&
 		hasSupervisorState &&
 		supervisorState.State == supervisor.SupervisorStateFailed &&

--- a/main_test.go
+++ b/main_test.go
@@ -745,7 +745,8 @@ func TestWhyCommand(t *testing.T) {
       "id": %q,
       "path": "_governator/tasks/%s.md",
       "kind": "execution",
-      "state": "triaged",
+      "state": "blocked",
+      "blocked_reason": "worker failed",
       "role": "default",
       "dependencies": [],
       "retries": {"max_attempts": 2},
@@ -816,7 +817,7 @@ func TestWhyCommand(t *testing.T) {
 		got := string(output)
 
 		if strings.Count(got, "=== ") != 3 {
-			t.Fatalf("expected exactly 3 sections (supervisor + blocked + failed), got output:\n%s", got)
+			t.Fatalf("expected exactly 3 sections (supervisor + 2 blocked tasks), got output:\n%s", got)
 		}
 		if !strings.Contains(got, "=== Supervisor 0 (unknown) last 2 lines ===\nline-29\nline-30\n") {
 			t.Fatalf("missing supervisor section in output:\n%s", got)
@@ -824,8 +825,8 @@ func TestWhyCommand(t *testing.T) {
 		if !strings.Contains(got, "=== Task "+blockedID+" (blocked) last 3 lines from _governator/_local-state/task-"+blockedID+"/_governator/_local-state/worker-2-work-default/stdout.log ===\nnew-2\nnew-3\nnew-4\n") {
 			t.Fatalf("missing blocked section with most recent stdout log in output:\n%s", got)
 		}
-		if !strings.Contains(got, "=== Task "+failedID+" (failed) last 3 lines from _governator/_local-state/task-"+failedID+"/_governator/_local-state/worker-1-test-default/stdout.log ===\nf-1\nf-2\nf-3\n") {
-			t.Fatalf("missing failed section in output:\n%s", got)
+		if !strings.Contains(got, "=== Task "+failedID+" (blocked) last 3 lines from _governator/_local-state/task-"+failedID+"/_governator/_local-state/worker-1-test-default/stdout.log ===\nf-1\nf-2\nf-3\n") {
+			t.Fatalf("missing second blocked section in output:\n%s", got)
 		}
 		if strings.Contains(got, openID) {
 			t.Fatalf("unexpected open task section in output:\n%s", got)
@@ -908,7 +909,8 @@ func TestWhyCommand(t *testing.T) {
       "id": "T-ERR-001",
       "path": "_governator/tasks/T-ERR-001.md",
       "kind": "execution",
-      "state": "triaged",
+      "state": "blocked",
+      "blocked_reason": "worker failed",
       "role": "default",
       "dependencies": [],
       "retries": {"max_attempts": 1},


### PR DESCRIPTION
Fixes #3

## Problem

The `gov why` command was showing tasks with historical failures even after they had successfully completed.

### Reproduction Steps
1. Start a project with tasks executing
2. Run `gov stop -w` to kill workers (increments `Attempts.Failed`)
3. Run `gov start` to restart
4. Tasks complete successfully (state changes to `merged`, etc.)
5. Run `gov why` - **incorrectly shows the completed tasks**

## Root Cause

The `whyTaskKind()` function in `main.go` was checking `if task.Attempts.Failed > 0` to determine if a task should appear in output. This matches **any task that has ever failed**, not just tasks that are currently failing.

When workers are killed:
- `task.Attempts.Failed` is incremented
- Task transitions to `blocked` state
- When task resumes and succeeds, it transitions to success states
- **But `Attempts.Failed` is never reset** - it remains as historical record

The old logic showed any task with historical failures, even if it had since recovered.

## Solution

Removed the `Attempts.Failed > 0` check from `whyTaskKind()`. Now the function only shows:
1. Tasks currently in `TaskStateBlocked` (actively blocked/failing)
2. Planning tasks that caused supervisor failure

This preserves the `Attempts.Failed` counter for observability while fixing the incorrect `gov why` output.

## Changes

**main.go:**
- Removed `if task.Attempts.Failed > 0 { return "failed" }` check
- Tasks with historical failures but current success states no longer appear

**main_test.go:**
- Updated test fixtures to use `state: "blocked"` instead of `state: "triaged"` with `failed: 1`
- Tests now correctly verify that only currently-blocked tasks appear in output

## Testing

All tests pass:
```
go test ./...
```

Manual verification shows completed tasks with historical failures no longer appear in `gov why` output.