### PR TITLE
Fix init to stamp pre-existing migrations as complete

### DIFF
--- a/internal/config/migrations.go
+++ b/internal/config/migrations.go
@@ -101,6 +101,38 @@ func pendingRepoMigrations(repoRoot string) ([]repoMigration, error) {
 	return pending, nil
 }
 
+// StampExistingMigrations marks all currently-known migrations as complete without
+// running them. Call this during init so that migrations predating a fresh project
+// are never surfaced as pending.
+func StampExistingMigrations(repoRoot string, opts InitOptions) error {
+	if strings.TrimSpace(repoRoot) == "" {
+		return fmt.Errorf("repo root cannot be empty")
+	}
+
+	migrationsDir := filepath.Join(repoRoot, repoDurableStateDir, "migrations")
+	if err := ensureDir(migrationsDir, opts); err != nil {
+		return fmt.Errorf("create migrations directory %s: %w", migrationsDir, err)
+	}
+
+	for _, migration := range repoMigrations {
+		if strings.TrimSpace(migration.id) == "" {
+			continue
+		}
+		markerPath := filepath.Join(migrationsDir, migration.id+".done")
+		exists, err := pathExists(markerPath)
+		if err != nil {
+			return fmt.Errorf("check migration marker %s: %w", markerPath, err)
+		}
+		if exists {
+			continue
+		}
+		if err := os.WriteFile(markerPath, []byte("ok\n"), 0o644); err != nil {
+			return fmt.Errorf("write migration marker %s: %w", markerPath, err)
+		}
+	}
+	return nil
+}
+
 // ApplyRepoMigrations applies idempotent durable migrations for existing repositories.
 func ApplyRepoMigrations(repoRoot string, opts InitOptions) error {
 	if strings.TrimSpace(repoRoot) == "" {

--- a/internal/config/migrations_test.go
+++ b/internal/config/migrations_test.go
@@ -595,6 +595,97 @@ func TestApplyRepoMigrationsResetOpenTasksStripRoleSuffixFailsOnCollision(t *tes
 	}
 }
 
+// TestStampExistingMigrationsWritesMarkers verifies that all known migrations get stamped.
+func TestStampExistingMigrationsWritesMarkers(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := StampExistingMigrations(repoRoot, InitOptions{}); err != nil {
+		t.Fatalf("StampExistingMigrations: %v", err)
+	}
+
+	for _, migration := range repoMigrations {
+		markerPath := filepath.Join(repoRoot, repoDurableStateDir, "migrations", migration.id+".done")
+		data, err := os.ReadFile(markerPath)
+		if err != nil {
+			t.Fatalf("read marker for %s: %v", migration.id, err)
+		}
+		if string(data) != "ok\n" {
+			t.Fatalf("marker content for %s = %q, want %q", migration.id, string(data), "ok\n")
+		}
+	}
+}
+
+// TestStampExistingMigrationsLeavesNoPending verifies that after stamping, no migrations are pending.
+func TestStampExistingMigrationsLeavesNoPending(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := StampExistingMigrations(repoRoot, InitOptions{}); err != nil {
+		t.Fatalf("StampExistingMigrations: %v", err)
+	}
+
+	pending, err := PendingRepoMigrations(repoRoot)
+	if err != nil {
+		t.Fatalf("PendingRepoMigrations: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("expected no pending migrations after stamp, got: %v", pending)
+	}
+}
+
+// TestStampExistingMigrationsPreservesExistingMarkers verifies idempotency.
+func TestStampExistingMigrationsPreservesExistingMarkers(t *testing.T) {
+	repoRoot := t.TempDir()
+	migrationsDir := filepath.Join(repoRoot, repoDurableStateDir, "migrations")
+	if err := os.MkdirAll(migrationsDir, 0o755); err != nil {
+		t.Fatalf("mkdir migrations: %v", err)
+	}
+	markerPath := filepath.Join(migrationsDir, conflictResolutionMigrationID+".done")
+	custom := []byte("custom-marker\n")
+	if err := os.WriteFile(markerPath, custom, 0o644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	if err := StampExistingMigrations(repoRoot, InitOptions{}); err != nil {
+		t.Fatalf("StampExistingMigrations: %v", err)
+	}
+
+	data, err := os.ReadFile(markerPath)
+	if err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if !bytes.Equal(data, custom) {
+		t.Fatalf("existing marker was overwritten: got %q, want %q", string(data), string(custom))
+	}
+}
+
+// TestStampExistingMigrationsRejectsEmptyRepoRoot verifies input validation.
+func TestStampExistingMigrationsRejectsEmptyRepoRoot(t *testing.T) {
+	err := StampExistingMigrations("", InitOptions{})
+	if err == nil {
+		t.Fatal("expected error for empty repo root")
+	}
+	if !strings.Contains(err.Error(), "repo root cannot be empty") {
+		t.Fatalf("expected repo root validation error, got: %v", err)
+	}
+}
+
+// TestInitFullLayoutThenStampLeavesNoPendingMigrations simulates the init flow.
+func TestInitFullLayoutThenStampLeavesNoPendingMigrations(t *testing.T) {
+	repoRoot := t.TempDir()
+	if err := InitFullLayout(repoRoot, InitOptions{}); err != nil {
+		t.Fatalf("InitFullLayout: %v", err)
+	}
+	if err := StampExistingMigrations(repoRoot, InitOptions{}); err != nil {
+		t.Fatalf("StampExistingMigrations: %v", err)
+	}
+
+	pending, err := PendingRepoMigrations(repoRoot)
+	if err != nil {
+		t.Fatalf("PendingRepoMigrations: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Fatalf("expected no pending migrations after init + stamp, got: %v", pending)
+	}
+}
+
 func initGitRepo(t *testing.T, repoRoot string) {
 	t.Helper()
 	runGitCommand(t, repoRoot, "init", "--initial-branch=main")

--- a/main.go
+++ b/main.go
@@ -210,6 +210,12 @@ OPTIONS:
 		os.Exit(1)
 	}
 
+	// Mark all pre-existing migrations as complete so they are never surfaced as pending.
+	if err := config.StampExistingMigrations(repoRoot, config.InitOptions{Verbose: verbose}); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
 	// Apply flag overrides to config if any were provided
 	if agentValue != "" || concurrencyValue != 0 || reasoningEffortValue != "" || branchValue != "" || timeoutValue != 0 {
 		if err := config.ApplyInitOverrides(repoRoot, config.InitOverrides{


### PR DESCRIPTION
When `governator init` creates a fresh project, migrations that predate
the initialization are irrelevant — init already creates the files those
migrations would produce. Without stamping them, `governator start`
would prompt the user to apply migrations that don't matter, including
destructive ones that could confuse or alarm the operator.

Add `StampExistingMigrations` to write `.done` markers for all known
migrations during init, so only future migrations are surfaced as
pending.

Fixes #15

https://claude.ai/code/session_01YP18fb8HhLNzzfEASm1t8e