### PR TITLE
Stage GOVERNATOR.md alongside _governator during init commit

### DIFF
--- a/main.go
+++ b/main.go
@@ -236,13 +236,13 @@ OPTIONS:
 }
 
 func commitInit(repoRoot string) error {
-	addCmd := exec.Command("git", "add", "--", "_governator")
+	addCmd := exec.Command("git", "add", "--", "_governator", "GOVERNATOR.md")
 	addCmd.Dir = repoRoot
 	if out, err := addCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git add _governator failed: %s: %w", strings.TrimSpace(string(out)), err)
+		return fmt.Errorf("git add failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
-	diffCmd := exec.Command("git", "diff", "--cached", "--quiet", "--", "_governator")
+	diffCmd := exec.Command("git", "diff", "--cached", "--quiet", "--", "_governator", "GOVERNATOR.md")
 	diffCmd.Dir = repoRoot
 	if err := diffCmd.Run(); err != nil {
 		var exitErr *exec.ExitError


### PR DESCRIPTION
Fixes #16: the init command now includes GOVERNATOR.md in both the
git-add and git-diff-cached steps so the user's intent document is
committed together with the scaffolded workspace.

https://claude.ai/code/session_01Tv2WTuHyd3ncPBxUBcyS4n