### PR TITLE
Fix test harness: create GOVERNATOR.md before running init

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -303,6 +303,11 @@ func TestInitCommand(t *testing.T) {
 		t.Fatalf("Failed to init git repo: %v", err)
 	}
 
+	// Create GOVERNATOR.md (required by commitInit)
+	if err := os.WriteFile(filepath.Join(tempDir, "GOVERNATOR.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatalf("Failed to create GOVERNATOR.md: %v", err)
+	}
+
 	// Run init command
 	cmd = exec.Command(binaryPath, "init")
 	output, err := cmd.CombinedOutput()
@@ -375,6 +380,11 @@ func TestRetryCommand(t *testing.T) {
 	gitInitCmd.Dir = tempDir
 	if out, err := gitInitCmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init failed: %v, output: %s", err, out)
+	}
+
+	// Create GOVERNATOR.md (required by commitInit)
+	if err := os.WriteFile(filepath.Join(tempDir, "GOVERNATOR.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatalf("Failed to create GOVERNATOR.md: %v", err)
 	}
 
 	initCmd := exec.Command(binaryPath, "init")
@@ -588,6 +598,11 @@ func TestStatusCommand(t *testing.T) {
 	gitCmd := exec.Command("git", "init")
 	if err := gitCmd.Run(); err != nil {
 		t.Fatalf("Failed to init git repo: %v", err)
+	}
+
+	// Create GOVERNATOR.md (required by commitInit)
+	if err := os.WriteFile(filepath.Join(tempDir, "GOVERNATOR.md"), []byte("# Test\n"), 0o644); err != nil {
+		t.Fatalf("Failed to create GOVERNATOR.md: %v", err)
 	}
 
 	t.Run("status without index fails", func(t *testing.T) {


### PR DESCRIPTION
Commit 78eeaf5 (#16 fix) made commitInit() stage GOVERNATOR.md
unconditionally, but the test harnesses for TestInitCommand,
TestRetryCommand, and TestStatusCommand never created that file,
causing git add to fail with "pathspec did not match any files".

https://claude.ai/code/session_01Y3fpYP3HAzz38vkySi9Rji